### PR TITLE
Import FoundationNetworking when needed.

### DIFF
--- a/Sources/SupabaseStorage/StorageApi.swift
+++ b/Sources/SupabaseStorage/StorageApi.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public class StorageApi {
     var url: String

--- a/Sources/SupabaseStorage/StorageBucketApi.swift
+++ b/Sources/SupabaseStorage/StorageBucketApi.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Storage Bucket API
 public class StorageBucketApi: StorageApi {

--- a/Sources/SupabaseStorage/StorageFileApi.swift
+++ b/Sources/SupabaseStorage/StorageFileApi.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Supabase Storage File API
 public class StorageFileApi: StorageApi {

--- a/Tests/SupabaseStorageTests/SupabaseStorageTests.swift
+++ b/Tests/SupabaseStorageTests/SupabaseStorageTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import SupabaseStorage
 import XCTest
 


### PR DESCRIPTION
Add `FoundationNetworking` if available.
This is allowing Linux platforms to compile the framework, since the migration of URL-related function to the `FoundationNetworking` framework.