### PR TITLE
Make StorageError initializer public

### DIFF
--- a/Sources/SupabaseStorage/StorageError.swift
+++ b/Sources/SupabaseStorage/StorageError.swift
@@ -3,6 +3,11 @@ import Foundation
 public struct StorageError: Error {
   public var statusCode: Int?
   public var message: String?
+      
+  public init(statusCode: Int? = nil, message: String? = nil) {
+    self.statusCode = statusCode
+    self.message = message
+  }
 }
 
 extension StorageError: LocalizedError {


### PR DESCRIPTION
I made the initializer from StorageError public so it can be used from outside of the package. This allows developers to make wrappers over certain functions and they can return `StorageError` as result if needed.

For example, I've created this extension over `StorageFileApi` and I would like to return `StorageError` if I cannot convert `UIImage` to `Data` 
<img width="749" alt="image" src="https://user-images.githubusercontent.com/8146514/163062321-17d3cf59-f11e-437f-8f30-84db449f6836.png">
