### PR TITLE
Add support for getting public URL for asset

### DIFF
--- a/Sources/SupabaseStorage/StorageFileApi.swift
+++ b/Sources/SupabaseStorage/StorageFileApi.swift
@@ -197,33 +197,25 @@ public class StorageFileApi: StorageApi {
         fileName: String = "",
         options: TransformOptions? = nil
     ) throws -> URL {
-        var queryStrings = [String]()
-        
-        if download {
-            queryStrings.append("download=\(fileName)")
-        }
-        
-        let renderPath: String
-        
-        if let options = options {
-            renderPath = "render/image"
-            queryStrings.append(options.asQueryString())
-        } else {
-            renderPath = "object"
-        }
-        
-        let query: String
-        
-        if queryStrings.isEmpty {
-            query = ""
-        } else {
-            query = "?\(queryStrings.joined(separator: "&"))"
-        }
-        
-        guard let url = URL(string: "\(url)/\(renderPath)/public/\(path)\(query)") else {
+        guard let url = URL(string: url) else {
             throw StorageError(message: "badURL")
         }
         
-        return url
+        let renderPath = options != nil ? "render/image" : "object"
+        
+        let downloadQueryItem = download ? [URLQueryItem(name: "download", value: fileName)] : []
+        let optionsQueryItems = options?.queryItems ?? []
+        
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.path = "\(renderPath)/public/\(path)"
+        components.queryItems = downloadQueryItem + optionsQueryItems
+        
+        guard let generatedUrl = components.url else {
+            throw StorageError(message: "badUrl")
+        }
+        
+        return generatedUrl
     }
 }

--- a/Sources/SupabaseStorage/StorageFileApi.swift
+++ b/Sources/SupabaseStorage/StorageFileApi.swift
@@ -184,4 +184,46 @@ public class StorageFileApi: StorageApi {
     }
     return data
   }
+    
+    /// Returns a public url for an asset.
+    /// - Parameters:
+    ///  - path: The file path to the asset. For example `folder/image.png`.
+    ///  - download: Whether the asset should be downloaded.
+    ///  - fileName: If specified, the file name for the asset that is downloaded.
+    ///  - options: Transform the asset before retrieving it on the client.
+    public func getPublicUrl(
+        path: String,
+        download: Bool = false,
+        fileName: String = "",
+        options: TransformOptions? = nil
+    ) throws -> URL {
+        var queryStrings = [String]()
+        
+        if download {
+            queryStrings.append("download=\(fileName)")
+        }
+        
+        let renderPath: String
+        
+        if let options = options {
+            renderPath = "render/image"
+            queryStrings.append(options.asQueryString())
+        } else {
+            renderPath = "object"
+        }
+        
+        let query: String
+        
+        if queryStrings.isEmpty {
+            query = ""
+        } else {
+            query = "?\(queryStrings.joined(separator: "&"))"
+        }
+        
+        guard let url = URL(string: "\(url)/\(renderPath)/public/\(path)\(query)") else {
+            throw StorageError(message: "badURL")
+        }
+        
+        return url
+    }
 }

--- a/Sources/SupabaseStorage/TransformOptions.swift
+++ b/Sources/SupabaseStorage/TransformOptions.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct TransformOptions {
     public var width: Int?
     public var height: Int?
@@ -19,29 +21,29 @@ public struct TransformOptions {
         self.format = format
     }
     
-    func asQueryString() -> String {
-        var parameters = [String]()
+    var queryItems: [URLQueryItem] {
+        var items = [URLQueryItem]()
         
         if let width = width {
-            parameters.append("width=\(width)")
+            items.append(URLQueryItem(name: "width", value: String(width)))
         }
         
         if let height = height {
-            parameters.append("height=\(height)")
+            items.append(URLQueryItem(name: "height", value: String(height)))
         }
         
         if let resize = resize {
-            parameters.append("resize=\(resize)")
-        }
-        
-        if let format = format {
-            parameters.append("format=\(format)")
+            items.append(URLQueryItem(name: "resize", value: resize))
         }
         
         if let quality = quality {
-            parameters.append("quality=\(quality)")
+            items.append(URLQueryItem(name: "quality", value: String(quality)))
         }
         
-        return parameters.joined(separator: "&")
+        if let format = format {
+            items.append(URLQueryItem(name: "format", value: format))
+        }
+        
+        return items
     }
 }

--- a/Sources/SupabaseStorage/TransformOptions.swift
+++ b/Sources/SupabaseStorage/TransformOptions.swift
@@ -1,0 +1,47 @@
+public struct TransformOptions {
+    public var width: Int?
+    public var height: Int?
+    public var resize: String?
+    public var quality: Int?
+    public var format: String?
+    
+    public init(
+        width: Int? = nil,
+        height: Int? = nil,
+        resize: String? = "cover",
+        quality: Int? = 80,
+        format: String? = "origin"
+    ) {
+        self.width = width
+        self.height = height
+        self.resize = resize
+        self.quality = quality
+        self.format = format
+    }
+    
+    func asQueryString() -> String {
+        var parameters = [String]()
+        
+        if let width = width {
+            parameters.append("width=\(width)")
+        }
+        
+        if let height = height {
+            parameters.append("height=\(height)")
+        }
+        
+        if let resize = resize {
+            parameters.append("resize=\(resize)")
+        }
+        
+        if let format = format {
+            parameters.append("format=\(format)")
+        }
+        
+        if let quality = quality {
+            parameters.append("quality=\(quality)")
+        }
+        
+        return parameters.joined(separator: "&")
+    }
+}

--- a/Tests/SupabaseStorageTests/SupabaseStorageTests.swift
+++ b/Tests/SupabaseStorageTests/SupabaseStorageTests.swift
@@ -54,4 +54,11 @@ final class SupabaseStorageTests: XCTestCase {
     let data = try await storage.from(id: bucket).download(path: "README.md")
     XCTAssertFalse(data.isEmpty)
   }
+    
+    func testGetPublicUrl() throws {
+        let urlWithNoQuery = try storage.from(id: bucket).getPublicUrl(path: "README.md")
+        XCTAssertNil(urlWithNoQuery.query)
+        let urlWithQuery = try storage.from(id: bucket).getPublicUrl(path: "README.md", download: true)
+        XCTAssertNotNil(urlWithQuery.query)
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for the `getPublicUrl` method on the StorageFileApi.

## What is the current behavior?

No method to get a public URL for an asset.

## What is the new behavior?

Adds method to get a public URL for an asset.

## Additional context

N/A
