### PR TITLE
update FileObject struct

### DIFF
--- a/Sources/SupabaseStorage/FileObject.swift
+++ b/Sources/SupabaseStorage/FileObject.swift
@@ -1,37 +1,28 @@
 public struct FileObject {
   public var name: String
-  public var bucket_id: String
-  public var owner: String
   public var id: String
   public var updatedAt: String
   public var createdAt: String
   public var lastAccessedAt: String
   public var metadata: [String: Any]
-  public var buckets: Bucket?
 
   public init?(from dictionary: [String: Any]) {
     guard
       let name = dictionary["name"] as? String,
-      let bucket_id = dictionary["bucket_id"] as? String,
-      let owner = dictionary["owner"] as? String,
       let id = dictionary["id"] as? String,
       let updatedAt = dictionary["updated_at"] as? String,
       let createdAt = dictionary["created_at"] as? String,
       let lastAccessedAt = dictionary["last_accessed_at"] as? String,
-      let metadata = dictionary["metadata"] as? [String: Any],
-      let buckets = dictionary["buckets"] as? [String: Any]
+      let metadata = dictionary["metadata"] as? [String: Any]
     else {
       return nil
     }
 
     self.name = name
-    self.bucket_id = bucket_id
-    self.owner = owner
     self.id = id
     self.updatedAt = updatedAt
     self.createdAt = createdAt
     self.lastAccessedAt = lastAccessedAt
     self.metadata = metadata
-    self.buckets = Bucket(from: buckets)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The .list method to list all the files in a bucket is not working and always returns an empty list and it is not related to policies.

## What is the new behavior?

The .list method is now returning the current list of files expected.

## Additional context

I assume there have been changes in the documentation for the listing functions as the previous .list function was trying to create a FileObject using the documentation from: https://supabase.github.io/storage-api/#/object/post_object_list__bucketName_

But it seems that the structure of the response of the current list endpoint has changed and is not returning the owner, bucket_id and buckets keys anymore. This is why they have been removed in the PR.
